### PR TITLE
UE 4.27 thread hang fix

### DIFF
--- a/Source/PingQoS/Public/PingQoSWorker.h
+++ b/Source/PingQoS/Public/PingQoSWorker.h
@@ -130,7 +130,10 @@ protected:
 		if(CurWaitTime >= 1)
 		{
 			UE_LOG(LogTemp, Log, TEXT("Timed out, end the stream"));
-			DataReceiveDelegate.ExecuteIfBound(Infos);
+			AsyncTask(ENamedThreads::GameThread, [&]()
+			{
+				DataReceiveDelegate.ExecuteIfBound(Infos);
+			});
 			return true;
 		}
 		return false;


### PR DESCRIPTION
If you closed a game after the subsystem was used, the game would remain in taskbar and would not close as the worker thread does not end

Tested on UE 4.27.2