### PR TITLE
Fixed build errors by removing function inlined in cpp and fixed init order to match decl

### DIFF
--- a/Source/PingQoS/Private/PingQoSSubsystem.cpp
+++ b/Source/PingQoS/Private/PingQoSSubsystem.cpp
@@ -9,7 +9,7 @@
 
 
 // Overload == for FPingQoSInfo. This is necessary for TArray comparisons
-inline bool operator==(const FPingQoSInfo& lhs, const FPingQoSInfo& rhs)
+bool operator==(const FPingQoSInfo& lhs, const FPingQoSInfo& rhs)
 {
 	return	lhs.URL == rhs.URL &&
 			lhs.IP == rhs.IP &&

--- a/Source/PingQoS/Public/PingQoSSubsystem.h
+++ b/Source/PingQoS/Public/PingQoSSubsystem.h
@@ -8,7 +8,7 @@
 
 #include "PingQoSSubsystem.generated.h"
 
-inline bool operator==(const FPingQoSInfo& lhs, const FPingQoSInfo& rhs);
+bool operator==(const FPingQoSInfo& lhs, const FPingQoSInfo& rhs);
 
 USTRUCT(BlueprintType)
 struct PINGQOS_API FPingQoSInfo

--- a/Source/PingQoS/Public/PingQoSWorker.h
+++ b/Source/PingQoS/Public/PingQoSWorker.h
@@ -31,10 +31,10 @@ public:
 	*/
 	FPingQoSWorker(const TArray<FPingQoSInfo> NewServerInfos, const FTimespan& InboundPacketWaitTime, int32 NewPingTimeoutTime, const TCHAR* InThreadName)
 		: ServerInfosRequested(NewServerInfos)
+		, PingTimeoutTime(NewPingTimeoutTime)
 		, Stopping(false)
 		, Thread(nullptr)
 		, ThreadName(InThreadName)
-		, PingTimeoutTime(NewPingTimeoutTime)
 		, PacketWaitTime(InboundPacketWaitTime)
 	{
 		SocketSubsystem = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM);


### PR DESCRIPTION
Thanks for this very useful plugin!

We saw an error and warnings :

- error: you may not portably define `inline` functions that are not supplied in header visible in the TU that uses the code. I have removed inline but I can move the definition in the header as an alternative (but I don't think there will ever be 10000s of objects to compare, so...)
- warning; the init order in a class ctor is based on the declaration, not the definition of the fields initializers. It raises a warning since the actual order is not the one defined. I have rearranged them.

Comments welcome. 
Thanks again!